### PR TITLE
Now sending RunList only the runs it needs

### DIFF
--- a/src/containers/SetupToMatchSystemList.js
+++ b/src/containers/SetupToMatchSystemList.js
@@ -69,7 +69,8 @@ export class SetupToMatchSystemList extends Component {
   displayBody() {
     if (this.isFormatSelected()) {
       if (this.isMatchingSystemSelected() && this.props.metrics.length > 0) {
-        return (<RunList runs={this.props.metrics} recordMatchingSystem={this.props.selectedRMS} matchRuns={this.props.matchRuns}/>);
+        const filteredRuns = _.filter(this.props.metrics, (r) => r.recordMatchSystemInterfaceId === this.props.selectedRMS.id);
+        return (<RunList runs={filteredRuns} recordMatchingSystem={this.props.selectedRMS} matchRuns={this.props.matchRuns}/>);
       } else {
         if (this.props.metrics.length > 0) {
           return this.latestMetrics().map(function(m) {


### PR DESCRIPTION
Previously, we sent in all runs for all systems. This change passes only the
runs for the record matching system being displayed.
