### PR TITLE
Fix run no response

### DIFF
--- a/src/middlewares/restructure_results.js
+++ b/src/middlewares/restructure_results.js
@@ -19,19 +19,23 @@ function restructure(payload) {
     recordMatchSystemInterfaceId: payload.recordMatchSystemInterfaceId,
     masterRecordSetId: payload.masterRecordSetId
   };
-  let matchResponses = payload.responses.filter((resp) => {
-    let resourceEntries = resp.message.entry.filter((e) => e.resource !== undefined);
-    let matchEvent = resourceEntries.find((e) => e.resource.event !== undefined && e.resource.event.code === "record-match");
-    return matchEvent !== undefined;
-  });
-  let allEntries = matchResponses.reduce((acc, currentValue) => acc.concat(...currentValue.message.entry), []);
-  let links = allEntries.filter((e) => e.link !== undefined);
-  newPayload.links = links.map((l) => {
-    const source = l.fullUrl;
-    const target = l.link.find((nl) => nl.relation === "related").url;
-    const score = l.search.score;
-    return {source, target, score};
-  });
+  if (payload.responses) {
+    let matchResponses = payload.responses.filter((resp) => {
+      let resourceEntries = resp.message.entry.filter((e) => e.resource !== undefined);
+      let matchEvent = resourceEntries.find((e) => e.resource.event !== undefined && e.resource.event.code === "record-match");
+      return matchEvent !== undefined;
+    });
+    let allEntries = matchResponses.reduce((acc, currentValue) => acc.concat(...currentValue.message.entry), []);
+    let links = allEntries.filter((e) => e.link !== undefined);
+    newPayload.links = links.map((l) => {
+      const source = l.fullUrl;
+      const target = l.link.find((nl) => nl.relation === "related").url;
+      const score = l.search.score;
+      return {source, target, score};
+    });
+  } else {
+    newPayload.links = [];
+  }
 
   return newPayload;
 }

--- a/test/middlewares/restructure_results_test.js
+++ b/test/middlewares/restructure_results_test.js
@@ -13,4 +13,13 @@ describe('restructureResults', () => {
     };
     restructureResults()(next)(action);
   });
+
+  it('will return an empty array of links when there is no response', () => {
+    const mr = {id: '1233', note: 'test'};
+    const action = {type: REQUEST_MATCH_RUN_FULFILLED, payload: mr};
+    const next = (a) => {
+      expect(a.payload.links).to.be.empty;
+    };
+    restructureResults()(next)(action);
+  });
 });


### PR DESCRIPTION
When a match run is created, but hasn't been picked up by the record matcher,
the response property will be undefined. This changes allows the middleware to properly handle this state.
